### PR TITLE
feat: add visual quality critic foundation

### DIFF
--- a/.github/workflows/tool-routing.yml
+++ b/.github/workflows/tool-routing.yml
@@ -4,16 +4,10 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'server/agent_loop.py'
-      - 'server/session_state.py'
-      - 'server/capability_router.py'
-      - 'server/capability_registry.py'
-      - 'server/capability_executor.py'
-      - 'server/blender_mcp_guided.py'
-      - 'server/product_animation_tools.py'
-      - 'server/spatial_tools.py'
+      - 'server/**'
       - 'blender_addon/openclaw_blender_bridge.py'
       - 'blender_addon/new_handlers_phase5.py'
+      - 'blender_addon/quality_handlers.py'
       - 'requirements.txt'
       - 'tests/test_capability_router.py'
       - 'tests/test_tool_choice.py'
@@ -22,6 +16,10 @@ on:
       - 'tests/test_guided_workflow_search.py'
       - 'tests/test_guided_surface.py'
       - 'tests/test_bridge_contracts.py'
+      - 'tests/test_visual_quality.py'
+      - 'tests/test_workflow_quality_gate.py'
+      - 'tests/test_visual_quality_live_contract.py'
+      - 'tests/test_quality_repair.py'
       - 'eval/run.py'
       - 'tests/test_eval_cli.py'
       - 'tests/test_bridge_e2e.py'
@@ -29,27 +27,13 @@ on:
   push:
     branches: [main]
     paths:
-      - 'server/agent_loop.py'
-      - 'server/session_state.py'
-      - 'server/capability_router.py'
-      - 'server/capability_registry.py'
-      - 'server/capability_executor.py'
-      - 'server/blender_mcp_guided.py'
-      - 'server/product_animation_tools.py'
-      - 'server/spatial_tools.py'
+      - 'server/**'
       - 'blender_addon/openclaw_blender_bridge.py'
       - 'blender_addon/new_handlers_phase5.py'
+      - 'blender_addon/quality_handlers.py'
       - 'requirements.txt'
-      - 'tests/test_capability_router.py'
-      - 'tests/test_tool_choice.py'
-      - 'tests/test_act_dispatch.py'
-      - 'tests/test_workflow_execution.py'
-      - 'tests/test_guided_workflow_search.py'
-      - 'tests/test_guided_surface.py'
-      - 'tests/test_bridge_contracts.py'
+      - 'tests/**'
       - 'eval/run.py'
-      - 'tests/test_eval_cli.py'
-      - 'tests/test_bridge_e2e.py'
       - '.github/workflows/tool-routing.yml'
   workflow_dispatch:
 
@@ -73,16 +57,20 @@ jobs:
           assert major == 1, f'expected MCP SDK v1, got {major}'
           assert FastMCP is not None
           PY
-      - name: Compile routing modules
+      - name: Compile routing and quality modules
         run: >-
           python -m py_compile
           server/capability_router.py
           server/capability_registry.py
           server/capability_executor.py
+          server/quality_repair.py
+          server/quality_loop.py
+          server/visual_quality.py
           server/session_state.py
           server/agent_loop.py
           server/blender_mcp_guided.py
-      - name: Run deterministic router, dispatch, workflow, and bridge-contract floor
+          blender_addon/quality_handlers.py
+      - name: Run deterministic routing, dispatch, quality, and bridge-contract floor
         run: >-
           python -m pytest
           tests/test_tool_choice.py
@@ -92,6 +80,10 @@ jobs:
           tests/test_guided_workflow_search.py
           tests/test_guided_surface.py
           tests/test_bridge_contracts.py
+          tests/test_visual_quality.py
+          tests/test_workflow_quality_gate.py
+          tests/test_visual_quality_live_contract.py
+          tests/test_quality_repair.py
           tests/test_eval_cli.py
           tests/test_bridge_e2e.py
           -q

--- a/blender_addon/openclaw_blender_bridge.py
+++ b/blender_addon/openclaw_blender_bridge.py
@@ -7625,6 +7625,16 @@ try:
 except Exception as _e:
     print(f"[OpenClaw] Phase 5 handlers not loaded: {_e}")
 
+try:
+    try:
+        from .quality_handlers import QUALITY_HANDLERS  # type: ignore
+    except Exception:
+        from quality_handlers import QUALITY_HANDLERS  # type: ignore
+    HANDLERS.update(QUALITY_HANDLERS)
+    print(f"[OpenClaw] Loaded {len(QUALITY_HANDLERS)} quality handlers ({', '.join(sorted(QUALITY_HANDLERS))})")
+except Exception as _e:
+    print(f"[OpenClaw] Quality handlers not loaded: {_e}")
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SOCKET SERVER (background thread) + TIMER (main thread execution)

--- a/blender_addon/quality_handlers.py
+++ b/blender_addon/quality_handlers.py
@@ -1,0 +1,60 @@
+"""Objective scene diagnostics for quality control. Addon-only; not an MCP tool."""
+from __future__ import annotations
+
+try:
+    import bpy
+except ImportError:
+    bpy = None  # type: ignore
+
+
+def handle_scene_diagnostics(params):
+    if bpy is None:
+        raise RuntimeError("scene_diagnostics requires Blender")
+    scene = bpy.context.scene
+    objects = [{"name": obj.name, "type": obj.type} for obj in scene.objects]
+    camera_obj = scene.camera or next((obj for obj in scene.objects if obj.type == "CAMERA"), None)
+    camera = None
+    if camera_obj is not None:
+        data = camera_obj.data
+        dof = getattr(data, "dof", None)
+        camera = {
+            "name": camera_obj.name,
+            "lens_mm": float(getattr(data, "lens", 0.0)),
+            "clip_start": float(getattr(data, "clip_start", 0.0)),
+            "clip_end": float(getattr(data, "clip_end", 0.0)),
+            "dof_enabled": bool(getattr(dof, "use_dof", False)) if dof else False,
+            "focus_object": getattr(getattr(dof, "focus_object", None), "name", None) if dof else None,
+            "focus_distance": float(getattr(dof, "focus_distance", 0.0)) if dof else None,
+            "aperture_fstop": float(getattr(dof, "aperture_fstop", 0.0)) if dof else None,
+        }
+    lights = []
+    for obj in scene.objects:
+        if obj.type == "LIGHT":
+            data = obj.data
+            lights.append({"name": obj.name, "type": str(getattr(data, "type", "")), "energy": float(getattr(data, "energy", 0.0))})
+    world = scene.world
+    world_info = {"present": world is not None, "name": world.name if world else None, "uses_nodes": bool(getattr(world, "use_nodes", False)) if world else False, "environment_textures": []}
+    if world and world.use_nodes and world.node_tree:
+        world_info["environment_textures"] = [node.image.filepath for node in world.node_tree.nodes if getattr(node, "type", "") == "TEX_ENVIRONMENT" and getattr(node, "image", None)]
+    render = scene.render
+    cycles = getattr(scene, "cycles", None)
+    return {
+        "objects": objects,
+        "object_count": len(objects),
+        "camera_present": camera is not None,
+        "camera": camera,
+        "light_count": len(lights),
+        "lights": lights,
+        "world": world_info,
+        "render": {
+            "engine": str(getattr(render, "engine", "")),
+            "resolution_x": int(getattr(render, "resolution_x", 0)),
+            "resolution_y": int(getattr(render, "resolution_y", 0)),
+            "resolution_percentage": int(getattr(render, "resolution_percentage", 0)),
+            "film_transparent": bool(getattr(render, "film_transparent", False)),
+            "samples": int(getattr(cycles, "samples", 0)) if cycles else None,
+        },
+    }
+
+
+QUALITY_HANDLERS = {"scene_diagnostics": handle_scene_diagnostics}

--- a/server/capability_executor.py
+++ b/server/capability_executor.py
@@ -20,6 +20,7 @@ try:
     )
     from server.spatial_tools import _format_ascii_floor_plan, _load_dimensions_db, _resolve_alias
     from server.visual_quality import critique_visual_evidence
+    from server.quality_loop import run_quality_loop
 except ModuleNotFoundError:
     from capability_registry import registry, Capability
     from product_animation_tools import (
@@ -31,6 +32,7 @@ except ModuleNotFoundError:
     )
     from spatial_tools import _format_ascii_floor_plan, _load_dimensions_db, _resolve_alias
     from visual_quality import critique_visual_evidence
+    from quality_loop import run_quality_loop
 
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9_. -]{1,128}$")
 _VISUAL_FAMILIES = {"lighting", "material", "camera", "render"}
@@ -235,10 +237,43 @@ def execute_canonical(key: str, arguments: dict, send_command, *, observe_visual
     return response
 
 
+def _is_unknown_bridge_command(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    err = str(result.get("error") or "")
+    return "unknown command" in err.lower()
+
+
 def _final_quality_review(key: str, object_name: str, send_command) -> dict:
-    scene = send_command("get_scene_info", {})
+    diagnostics = send_command("scene_diagnostics", {})
+    if _has_error(diagnostics) or _is_unknown_bridge_command(diagnostics):
+        diagnostics = send_command("get_scene_info", {})
     viewport = _visual_observation(send_command)
-    return critique_visual_evidence(scene=scene, viewport=viewport, workflow=key, target_object=object_name)
+    return critique_visual_evidence(
+        scene=diagnostics,
+        viewport=viewport,
+        diagnostics=diagnostics if not _is_unknown_bridge_command(diagnostics) else None,
+        workflow=key,
+        target_object=object_name,
+    )
+
+
+def _complete_product_quality(key: str, object_name: str, send_command, steps: list) -> dict:
+    def review_once() -> dict:
+        return _final_quality_review(key, object_name, send_command)
+
+    def exec_cap(cap_key: str, arguments: dict) -> dict:
+        return execute_canonical(cap_key, arguments, send_command, observe_visual=False)
+
+    review = run_quality_loop(
+        workflow=key,
+        target_object=object_name,
+        review_once=review_once,
+        execute_canonical=exec_cap,
+    )
+    for attempt in review.get("repair_attempts") or []:
+        steps.append({"capability": "quality.repair", "result": attempt})
+    return review
 
 
 def execute_workflow(key: str, arguments: dict, send_command) -> dict:
@@ -273,7 +308,7 @@ def execute_workflow(key: str, arguments: dict, send_command) -> dict:
             return fail()
         if bool(args.get("auto_render", False)) and not run("scene.render", {"type": "image"}, observe_visual=True):
             return fail()
-        review = _final_quality_review(key, object_name, send_command)
+        review = _complete_product_quality(key, object_name, send_command, steps)
         return {"workflow": key, "status": review["status"], "object_name": object_name, "steps": steps, "quality_review": review, "postcondition": "Turntable stage produced pixels and completed objective quality review."}
     if key == "workflow.amazon_packshot":
         args = {**args, "lighting": "product_studio", "camera_style": "hero_reveal", "quality": "premium", "resolution": "square_1080", "transparent_bg": bool(args.get("transparent_bg", True)), "auto_render": True}
@@ -288,5 +323,5 @@ def execute_workflow(key: str, arguments: dict, send_command) -> dict:
         return fail()
     if bool(args.get("auto_render", True)) and not run("scene.render", {"type": "image"}, observe_visual=True):
         return fail()
-    review = _final_quality_review(key, object_name, send_command)
+    review = _complete_product_quality(key, object_name, send_command, steps)
     return {"workflow": key, "status": review["status"], "object_name": object_name, "steps": steps, "quality_review": review, "postcondition": "Appearance steps produced pixels and workflow completed objective quality review."}

--- a/server/capability_executor.py
+++ b/server/capability_executor.py
@@ -19,6 +19,7 @@ try:
         _gen_compositor_code,
     )
     from server.spatial_tools import _format_ascii_floor_plan, _load_dimensions_db, _resolve_alias
+    from server.visual_quality import critique_visual_evidence
 except ModuleNotFoundError:
     from capability_registry import registry, Capability
     from product_animation_tools import (
@@ -29,6 +30,7 @@ except ModuleNotFoundError:
         _gen_compositor_code,
     )
     from spatial_tools import _format_ascii_floor_plan, _load_dimensions_db, _resolve_alias
+    from visual_quality import critique_visual_evidence
 
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9_. -]{1,128}$")
 _VISUAL_FAMILIES = {"lighting", "material", "camera", "render"}
@@ -66,7 +68,6 @@ def _has_error(result: Any) -> bool:
 
 
 def _has_visual_evidence(obs: Any) -> bool:
-    """Return True only when the bridge returned actual image pixels."""
     if not isinstance(obs, dict) or obs.get("error"):
         return False
     payload = obs.get("data", obs)
@@ -158,19 +159,9 @@ def _execute_product(cap: Capability, args: dict, send_command) -> dict:
 def _execute_spatial_adapter(key: str, args: dict, send_command) -> dict:
     if key == "scene.spatial_query":
         action = str(args.get("action") or "scene_bounds")
-        commands = {
-            "raycast": "spatial_raycast",
-            "bounding_box_world": "spatial_bbox_world",
-            "check_collision": "spatial_check_collision",
-            "find_placement_position": "spatial_find_placement",
-            "get_safe_movement_range": "spatial_movement_range",
-            "scene_bounds": "spatial_scene_bounds",
-        }
+        commands = {"raycast": "spatial_raycast", "bounding_box_world": "spatial_bbox_world", "check_collision": "spatial_check_collision", "find_placement_position": "spatial_find_placement", "get_safe_movement_range": "spatial_movement_range", "scene_bounds": "spatial_scene_bounds"}
         command = commands.get(action)
-        if not command:
-            return {"error": f"unknown spatial action: {action}"}
-        return send_command(command, args)
-
+        return send_command(command, args) if command else {"error": f"unknown spatial action: {action}"}
     if key == "scene.dimensions":
         action = str(args.get("action") or "")
         db = _load_dimensions_db()
@@ -198,7 +189,6 @@ def _execute_spatial_adapter(key: str, args: dict, send_command) -> dict:
             target = db.get("objects", {}).get(resolved)
             return send_command("dimensions_scale", {"name": name, "target_dimensions": target}) if target else {"error": f"'{object_type}' not in dimensions DB"}
         return {"error": f"unknown dimensions action: {action}"}
-
     if key == "scene.floor_plan":
         axis = str(args.get("axis") or "z")
         data = send_command("floor_plan_data", {"axis": axis})
@@ -206,7 +196,6 @@ def _execute_spatial_adapter(key: str, args: dict, send_command) -> dict:
             return data
         objects = data.get("objects", []) if isinstance(data, dict) else []
         return {"floor_plan": _format_ascii_floor_plan(objects, int(args.get("width", 80)), int(args.get("height", 30)), axis), "object_count": len(objects), "axis": axis}
-
     return registry.execute(key, args, send_command)
 
 
@@ -246,6 +235,12 @@ def execute_canonical(key: str, arguments: dict, send_command, *, observe_visual
     return response
 
 
+def _final_quality_review(key: str, object_name: str, send_command) -> dict:
+    scene = send_command("get_scene_info", {})
+    viewport = _visual_observation(send_command)
+    return critique_visual_evidence(scene=scene, viewport=viewport, workflow=key, target_object=object_name)
+
+
 def execute_workflow(key: str, arguments: dict, send_command) -> dict:
     if key not in WORKFLOW_SCHEMAS:
         raise KeyError(f"Unknown workflow capability: {key}")
@@ -278,7 +273,8 @@ def execute_workflow(key: str, arguments: dict, send_command) -> dict:
             return fail()
         if bool(args.get("auto_render", False)) and not run("scene.render", {"type": "image"}, observe_visual=True):
             return fail()
-        return {"workflow": key, "status": "ok", "object_name": object_name, "steps": steps, "postcondition": "Turntable camera orbit was created with pixel observation."}
+        review = _final_quality_review(key, object_name, send_command)
+        return {"workflow": key, "status": review["status"], "object_name": object_name, "steps": steps, "quality_review": review, "postcondition": "Turntable stage produced pixels and completed objective quality review."}
     if key == "workflow.amazon_packshot":
         args = {**args, "lighting": "product_studio", "camera_style": "hero_reveal", "quality": "premium", "resolution": "square_1080", "transparent_bg": bool(args.get("transparent_bg", True)), "auto_render": True}
     material = args.get("material")
@@ -292,4 +288,5 @@ def execute_workflow(key: str, arguments: dict, send_command) -> dict:
         return fail()
     if bool(args.get("auto_render", True)) and not run("scene.render", {"type": "image"}, observe_visual=True):
         return fail()
-    return {"workflow": key, "status": "ok", "object_name": object_name, "steps": steps, "postcondition": "Every appearance-affecting step produced pixel evidence."}
+    review = _final_quality_review(key, object_name, send_command)
+    return {"workflow": key, "status": review["status"], "object_name": object_name, "steps": steps, "quality_review": review, "postcondition": "Appearance steps produced pixels and workflow completed objective quality review."}

--- a/server/capability_registry.py
+++ b/server/capability_registry.py
@@ -22,6 +22,7 @@ _SCHEMA_OVERRIDES = {
     "scene.delete_object": {"type": "object", "required": ["names"], "properties": {"names": {"type": "array", "items": {"type": "string"}}}, "additionalProperties": False},
     "scene.set_material": {"type": "object", "required": ["object_name"], "properties": {"object_name": {"type": "string"}, "material_name": {"type": "string"}, "color": {"type": "array", "items": {"type": "number"}}, "metallic": {"type": "number"}, "roughness": {"type": "number"}}},
     "scene.info": {"type": "object", "properties": {}, "additionalProperties": False},
+    "scene.diagnostics": {"type": "object", "properties": {}, "additionalProperties": False},
     "scene.render": {"type": "object", "properties": {"type": {"type": "string", "enum": ["image", "animation"], "default": "image"}, "output_path": {"type": "string"}}, "additionalProperties": False},
 }
 
@@ -81,7 +82,7 @@ _SPECIFIC_FAMILIES = {
     "scene.create_object": "create", "scene.modify_object": "mutate", "scene.delete_object": "mutate",
     "scene.lighting_preset": "lighting", "product.lighting": "lighting", "scene.world": "world",
     "scene.set_material": "material", "material.shader_nodes": "material", "material.procedural": "material", "material.texture_bake": "material",
-    "scene.info": "inspect", "scene.object_info": "inspect", "scene.render": "render", "scene.render_settings": "render", "scene.render_audit": "render",
+    "scene.info": "inspect", "scene.object_info": "inspect", "scene.diagnostics": "inspect", "scene.render": "render", "scene.render_settings": "render", "scene.render_audit": "render",
     "scene.camera": "camera", "product.camera": "camera",
 }
 
@@ -174,6 +175,17 @@ def _build_registry() -> CapabilityRegistry:
         aliases = (source.command, *source.positive) if source.command != bridge_command else tuple(source.positive)
         caps.append(Capability(key=key, family=family, description=source.purpose, bridge_command=bridge_command, mcp_name=source.tool, input_schema=_SCHEMA_OVERRIDES.get(key, dict(_GENERIC_SCHEMA)), aliases=aliases, tags=(source.family,), mutates_scene=source.mutates_scene))
     caps.append(Capability(key="scene.delete_object", family="mutate", description="delete one or more named scene objects", bridge_command="delete_object", mcp_name="blender_delete_object", input_schema=_SCHEMA_OVERRIDES["scene.delete_object"], aliases=("delete object", "remove object", "delete default cube"), tags=("objects",), mutates_scene=True))
+    caps.append(Capability(
+        key="scene.diagnostics",
+        family="inspect",
+        description="typed scene diagnostics: objects, camera/DOF, lights, world/HDRI, render engine/samples",
+        bridge_command="scene_diagnostics",
+        mcp_name="blender_scene_diagnostics",
+        input_schema=_SCHEMA_OVERRIDES["scene.diagnostics"],
+        aliases=("scene diagnostics", "quality diagnostics", "camera dof inspect"),
+        tags=("inspect", "quality"),
+        mutates_scene=False,
+    ))
     return CapabilityRegistry(caps)
 
 

--- a/server/quality_loop.py
+++ b/server/quality_loop.py
@@ -1,0 +1,55 @@
+"""Bounded detect -> repair -> recapture -> verify controller.
+
+This controller is MCP-independent and delegates every mutation to the existing
+canonical executor supplied by capability_executor. It never auto-repairs
+semantic/aesthetic review findings.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+try:
+    from server.quality_repair import next_objective_repair, repair_budget
+except ModuleNotFoundError:
+    from quality_repair import next_objective_repair, repair_budget
+
+
+def run_quality_loop(
+    *,
+    workflow: str,
+    target_object: str,
+    review_once: Callable[[], dict],
+    execute_canonical: Callable[[str, dict], dict],
+    max_repairs: int | None = None,
+) -> dict:
+    budget = repair_budget() if max_repairs is None else max(0, int(max_repairs))
+    attempts: list[dict] = []
+    review = review_once()
+
+    for iteration in range(budget + 1):
+        if review.get("status") != "fail":
+            return {**review, "repair_attempts": attempts, "repair_count": len(attempts), "repair_budget": budget}
+        if iteration >= budget:
+            break
+        action = next_objective_repair(review, workflow=workflow, target_object=target_object)
+        if action is None:
+            break
+        if not action.repairable or not action.capability:
+            attempts.append({"iteration": iteration + 1, "finding_code": action.finding_code, "status": "not_repairable", "reason": action.reason})
+            break
+        if action.capability == "scene.viewport_capture":
+            # NO_PIXELS is an observation retry, not a scene mutation. review_once
+            # performs the fresh base64 capture immediately below.
+            outcome = {"status": "ok", "observation_retry": True}
+        else:
+            outcome = execute_canonical(action.capability, action.arguments)
+        attempt = {"iteration": iteration + 1, "finding_code": action.finding_code, "capability": action.capability, "arguments": action.arguments, "outcome_status": outcome.get("status") if isinstance(outcome, dict) else None}
+        attempts.append(attempt)
+        if not isinstance(outcome, dict) or outcome.get("status") not in {"ok", "review_required", "pass"}:
+            attempt["status"] = "repair_failed"
+            break
+        attempt["status"] = "executed"
+        # Mandatory recapture/re-diagnosis after exactly one repair.
+        review = review_once()
+
+    return {**review, "repair_attempts": attempts, "repair_count": len(attempts), "repair_budget": budget}

--- a/server/quality_repair.py
+++ b/server/quality_repair.py
@@ -1,0 +1,61 @@
+"""Deterministic objective-quality repair policy.
+
+Only objective error findings are repairable here. Semantic/aesthetic review
+findings are deliberately never converted into automatic mutations.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_MAX_REPAIRS = 3
+
+
+@dataclass(frozen=True)
+class RepairAction:
+    finding_code: str
+    capability: str | None
+    arguments: dict
+    repairable: bool
+    reason: str
+
+
+def repair_budget() -> int:
+    raw = os.getenv("OPENCLAW_QUALITY_REPAIR_MAX", str(DEFAULT_MAX_REPAIRS)).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_REPAIRS
+    return max(0, min(value, 10))
+
+
+def repair_for_finding(finding: dict[str, Any], *, workflow: str, target_object: str) -> RepairAction:
+    code = str(finding.get("code") or "")
+    severity = str(finding.get("severity") or "")
+    if severity == "review":
+        return RepairAction(code, None, {}, False, "semantic/aesthetic review requires client-visible pixels")
+    if code == "NO_CAMERA":
+        style = "turntable" if workflow == "workflow.turntable" else "hero_reveal"
+        return RepairAction(code, "product.camera", {"style": style, "target_object": target_object}, True, "create workflow-appropriate product camera")
+    if code == "NO_LIGHTS":
+        return RepairAction(code, "product.lighting", {"preset": "product_studio", "shadow_catcher": True}, True, "create deterministic studio lighting")
+    if code == "NO_PIXELS":
+        return RepairAction(code, "scene.viewport_capture", {"base64": True}, True, "recapture model-visible pixels")
+    if code == "TARGET_MISSING":
+        return RepairAction(code, None, {}, False, "target identity cannot be safely invented")
+    return RepairAction(code, None, {}, False, "no deterministic repair policy")
+
+
+def next_objective_repair(review: dict[str, Any], *, workflow: str, target_object: str) -> RepairAction | None:
+    """Return at most one repair for the current critique iteration."""
+    for finding in review.get("findings") or []:
+        if not isinstance(finding, dict) or finding.get("severity") != "error":
+            continue
+        action = repair_for_finding(finding, workflow=workflow, target_object=target_object)
+        if action.repairable:
+            return action
+        # An objective error with no safe repair is fail-closed; do not skip past
+        # it and mutate some other aspect of the scene.
+        return action
+    return None

--- a/server/verify.py
+++ b/server/verify.py
@@ -1,546 +1,361 @@
+"""Evidence-backed geometric verification for the Blender MCP.
+
+This module deliberately does not contain a server-side aesthetic pass bit.
+Objective constraints are evaluated from real addon handlers. Subjective visual
+judgement is returned as ``review_required`` so a client that can actually see
+pixels can make that decision.
 """
-Constraint Verification Module for OpenClaw Blender MCP
-========================================================
-Geometric Constraint Satisfaction (GCS) + Vision-as-a-Judge verification.
+from __future__ import annotations
 
-Reference: Constraint-based verification of spatial relationships and action
-outcomes. Deterministic checks (on_top_of, clearance, triangulated, etc.) with
-VLM fallback for semantic verification.
-
-Install: Standard library only (json, base64, re, socket).
-Usage:
-  from verify import verify_action, run_gcs, vlm_judge
-  result = verify_action(
-      send_command,
-      expected="placed object on surface",
-      constraints=[{"type": "on_top_of", "object": "cube", "support": "plane"}],
-      use_vlm=True
-  )
-"""
-
-import json
-import base64
-import re
-import socket
+import math
 from dataclasses import dataclass, asdict
-from typing import Optional, List, Dict, Any, Callable
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+SendCommand = Callable[[str, Dict[str, Any]], Dict[str, Any]]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _payload(result: Any) -> dict:
+    if not isinstance(result, dict):
+        return {}
+    data = result.get("data", result)
+    return data if isinstance(data, dict) else {}
+
+
+def _error(result: Any) -> Optional[str]:
+    if not isinstance(result, dict):
+        return "non-dict bridge response"
+    if result.get("error"):
+        return str(result["error"])
+    status = str(result.get("status") or "").lower()
+    if status in {"failed", "postcondition_failed", "partial_failure"}:
+        return str(result.get("error") or status)
+    return None
+
+
+def _scene_objects(send_command: SendCommand) -> tuple[list[dict], Optional[str]]:
+    result = send_command("get_scene_info", {})
+    err = _error(result)
+    if err:
+        return [], err
+    rows = _payload(result).get("objects") or []
+    return [row for row in rows if isinstance(row, dict)], None
+
+
+def _scene_object(send_command: SendCommand, name: str) -> tuple[Optional[dict], Optional[str]]:
+    rows, err = _scene_objects(send_command)
+    if err:
+        return None, err
+    row = next((row for row in rows if str(row.get("name")) == name), None)
+    if row is None:
+        return None, f"object '{name}' not found"
+    return row, None
+
+
+def _bbox(send_command: SendCommand, name: str) -> tuple[Optional[dict], Optional[str]]:
+    result = send_command("spatial_bbox_world", {"name": name})
+    err = _error(result)
+    if err:
+        return None, err
+    box = _payload(result).get("bbox")
+    if not isinstance(box, dict):
+        return None, f"spatial_bbox_world returned no bbox for '{name}'"
+    if not all(isinstance(box.get(key), list) and len(box[key]) == 3 for key in ("min", "max")):
+        return None, f"invalid bbox shape for '{name}'"
+    return box, None
+
+
+def _axis_gap(a: dict, b: dict, axis: int) -> float:
+    if a["max"][axis] < b["min"][axis]:
+        return float(b["min"][axis] - a["max"][axis])
+    if b["max"][axis] < a["min"][axis]:
+        return float(a["min"][axis] - b["max"][axis])
+    return 0.0
+
+
+def _aabb_distance(a: dict, b: dict) -> float:
+    gaps = [_axis_gap(a, b, axis) for axis in range(3)]
+    return math.sqrt(sum(gap * gap for gap in gaps))
+
+
+def _penetration(a: dict, b: dict) -> list[float]:
+    return [
+        min(float(a["max"][axis]), float(b["max"][axis]))
+        - max(float(a["min"][axis]), float(b["min"][axis]))
+        for axis in range(3)
+    ]
 
 
 @dataclass
 class GCSConstraint:
-    """Geometric Constraint Satisfaction constraint specification."""
-    type: str  # on_top_of, inside, not_overlapping, clearance, facing, vertex_count_range, triangulated, has_material, axis_aligned
+    type: str
     object: Optional[str] = None
     support: Optional[str] = None
     distance: Optional[float] = None
     tolerance: Optional[float] = None
-    direction: Optional[str] = None  # x, y, z, +x, -y, etc.
+    direction: Optional[str] = None
     min_vertices: Optional[int] = None
     max_vertices: Optional[int] = None
     material_name: Optional[str] = None
-    axis: Optional[str] = None  # x, y, z
+    axis: Optional[str] = None
 
 
 @dataclass
 class VerificationResult:
-    """Result of a single constraint check."""
     passed: bool
     constraint: Dict[str, Any]
     detail: str
     measured: Optional[Dict[str, Any]] = None
+    evidence_status: str = "verified"
 
 
-def check_constraint(
-    send_command: Callable[[str, Dict[str, Any]], Dict[str, Any]],
-    constraint: Dict[str, Any]
-) -> VerificationResult:
-    """
-    Check a single GCS constraint deterministically.
+def _fail(constraint: dict, detail: str, measured: Optional[dict] = None, *, status: str = "unavailable") -> VerificationResult:
+    return VerificationResult(False, constraint, detail, measured, status)
 
-    Args:
-        send_command: Socket-based Blender command sender
-        constraint: Dict with 'type' and constraint-specific fields
 
-    Returns:
-        VerificationResult with passed bool, detail, and measured data
-    """
-    constraint_type = constraint.get("type", "unknown")
+def check_constraint(send_command: SendCommand, constraint: Dict[str, Any]) -> VerificationResult:
+    """Evaluate one objective constraint from registered bridge evidence."""
+    ctype = str(constraint.get("type") or "unknown")
+    obj_name = constraint.get("object")
+    support_name = constraint.get("support")
+    tolerance = float(constraint.get("tolerance", 0.02) or 0.02)
 
     try:
-        if constraint_type == "on_top_of":
-            obj_name = constraint.get("object")
-            support_name = constraint.get("support")
+        if ctype == "on_top_of":
             if not obj_name or not support_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object or support name",
-                    measured=None
-                )
-
-            result = send_command("get_relative_position", {
-                "object": obj_name,
-                "reference": support_name
-            })
-            data = result.get("data", {})
-            z_height = data.get("z", 0)
-            is_above = z_height > 0.01
-
+                return _fail(constraint, "on_top_of requires object and support")
+            obj_box, err = _bbox(send_command, str(obj_name))
+            if err:
+                return _fail(constraint, err)
+            support_box, err = _bbox(send_command, str(support_name))
+            if err:
+                return _fail(constraint, err)
+            vertical_gap = float(obj_box["min"][2] - support_box["max"][2])
+            overlap_x = min(obj_box["max"][0], support_box["max"][0]) - max(obj_box["min"][0], support_box["min"][0])
+            overlap_y = min(obj_box["max"][1], support_box["max"][1]) - max(obj_box["min"][1], support_box["min"][1])
+            passed = abs(vertical_gap) <= tolerance and overlap_x > 0 and overlap_y > 0
             return VerificationResult(
-                passed=is_above,
-                constraint=constraint,
-                detail=f"{obj_name} z-height relative to {support_name}: {z_height:.3f}",
-                measured={"z_height": z_height, "above": is_above}
+                passed,
+                constraint,
+                f"vertical gap={vertical_gap:.4f}m, xy overlap=({overlap_x:.4f},{overlap_y:.4f})m",
+                {"vertical_gap": vertical_gap, "overlap_x": overlap_x, "overlap_y": overlap_y, "tolerance": tolerance},
             )
 
-        elif constraint_type == "clearance":
-            obj_name = constraint.get("object")
-            min_dist = constraint.get("distance", 0.1)
-            tolerance = constraint.get("tolerance", 0.01)
+        if ctype == "inside":
+            if not obj_name or not support_name:
+                return _fail(constraint, "inside requires object and support/container")
+            obj_box, err = _bbox(send_command, str(obj_name))
+            if err:
+                return _fail(constraint, err)
+            container_box, err = _bbox(send_command, str(support_name))
+            if err:
+                return _fail(constraint, err)
+            inside = all(
+                obj_box["min"][axis] >= container_box["min"][axis] - tolerance
+                and obj_box["max"][axis] <= container_box["max"][axis] + tolerance
+                for axis in range(3)
+            )
+            return VerificationResult(inside, constraint, f"{obj_name} inside {support_name}: {inside}", {"tolerance": tolerance})
 
+        if ctype == "not_overlapping":
+            if not obj_name or not support_name:
+                return _fail(constraint, "not_overlapping requires object and support")
+            a, err = _bbox(send_command, str(obj_name))
+            if err:
+                return _fail(constraint, err)
+            b, err = _bbox(send_command, str(support_name))
+            if err:
+                return _fail(constraint, err)
+            penetration = _penetration(a, b)
+            # Touching at a surface is not volumetric overlap. Require positive
+            # penetration beyond tolerance on all axes before declaring overlap.
+            overlapping = all(value > tolerance for value in penetration)
+            return VerificationResult(
+                not overlapping,
+                constraint,
+                f"volumetric overlap={overlapping}; penetration={penetration}",
+                {"penetration": penetration, "tolerance": tolerance, "overlapping": overlapping},
+            )
+
+        if ctype == "clearance":
             if not obj_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object name",
-                    measured=None
-                )
-
-            result = send_command("get_min_clearance", {"object": obj_name})
-            data = result.get("data", {})
-            measured_dist = data.get("min_distance", 0)
-            passed = measured_dist >= (min_dist - tolerance)
-
+                return _fail(constraint, "clearance requires object")
+            required = float(constraint.get("distance", 0.1) or 0.1)
+            target_box, err = _bbox(send_command, str(obj_name))
+            if err:
+                return _fail(constraint, err)
+            rows, err = _scene_objects(send_command)
+            if err:
+                return _fail(constraint, err)
+            nearest: Optional[tuple[str, float]] = None
+            for row in rows:
+                other = str(row.get("name") or "")
+                if not other or other == obj_name or str(row.get("type") or "").upper() not in {"MESH", "CURVE", "SURFACE", "FONT", "META"}:
+                    continue
+                box, box_err = _bbox(send_command, other)
+                if box_err or box is None:
+                    continue
+                distance = _aabb_distance(target_box, box)
+                if nearest is None or distance < nearest[1]:
+                    nearest = (other, distance)
+            if nearest is None:
+                return VerificationResult(True, constraint, "no other geometry available to violate clearance", {"nearest": None, "required": required})
+            passed = nearest[1] + tolerance >= required
             return VerificationResult(
-                passed=passed,
-                constraint=constraint,
-                detail=f"Clearance check: {measured_dist:.3f}m vs required {min_dist:.3f}m",
-                measured={"min_distance": measured_dist, "required": min_dist}
+                passed,
+                constraint,
+                f"nearest={nearest[0]} at {nearest[1]:.4f}m; required={required:.4f}m",
+                {"nearest_object": nearest[0], "min_distance": nearest[1], "required": required, "tolerance": tolerance},
             )
 
-        elif constraint_type == "inside":
-            obj_name = constraint.get("object")
-            container_name = constraint.get("support")
-
-            if not obj_name or not container_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object or container name",
-                    measured=None
-                )
-
-            result = send_command("is_inside_bounds", {
-                "object": obj_name,
-                "container": container_name
-            })
-            data = result.get("data", {})
-            is_inside = data.get("inside", False)
-
-            return VerificationResult(
-                passed=is_inside,
-                constraint=constraint,
-                detail=f"{obj_name} inside {container_name}: {is_inside}",
-                measured={"inside": is_inside}
-            )
-
-        elif constraint_type == "triangulated":
-            obj_name = constraint.get("object")
-
+        if ctype in {"has_material", "vertex_count_range", "axis_aligned", "triangulated", "facing"}:
             if not obj_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object name",
-                    measured=None
+                return _fail(constraint, f"{ctype} requires object")
+            row, err = _scene_object(send_command, str(obj_name))
+            if err or row is None:
+                return _fail(constraint, err or "object evidence unavailable")
+
+            if ctype == "has_material":
+                materials = [m for m in (row.get("materials") or []) if m]
+                target = constraint.get("material_name")
+                passed = (target in materials) if target else bool(materials)
+                return VerificationResult(passed, constraint, f"materials={materials}", {"materials": materials, "target": target})
+
+            if ctype == "vertex_count_range":
+                value = row.get("vertex_count")
+                if not isinstance(value, int):
+                    return _fail(constraint, "vertex_count unavailable from scene evidence")
+                low = int(constraint.get("min_vertices", 0) or 0)
+                high = int(constraint.get("max_vertices", 999999) or 999999)
+                passed = low <= value <= high
+                return VerificationResult(passed, constraint, f"vertices={value}, range={low}-{high}", {"vertex_count": value, "min": low, "max": high})
+
+            if ctype == "axis_aligned":
+                rotation = row.get("rotation_euler")
+                if not isinstance(rotation, list) or len(rotation) != 3:
+                    return _fail(constraint, "rotation_euler unavailable from scene evidence")
+                axis = str(constraint.get("axis") or "z").lower()
+                idx = {"x": 0, "y": 1, "z": 2}.get(axis)
+                if idx is None:
+                    return _fail(constraint, f"unknown axis '{axis}'")
+                angle = float(rotation[idx]) % math.tau
+                distance_to_axis = min(abs(angle), abs(angle - math.pi), abs(angle - math.tau))
+                passed = distance_to_axis <= tolerance
+                return VerificationResult(passed, constraint, f"axis {axis} deviation={distance_to_axis:.4f}rad", {"rotation_rad": angle, "deviation": distance_to_axis, "tolerance": tolerance})
+
+            if ctype == "triangulated":
+                return _fail(
+                    constraint,
+                    "triangulated cannot be proven from current registered inspection evidence; refusing to infer from face count",
+                    {"face_count": row.get("face_count")},
+                    status="not_proven",
                 )
 
-            result = send_command("get_mesh_info", {"object": obj_name})
-            data = result.get("data", {})
-            face_count = data.get("face_count", 0)
-            is_triangulated = all(
-                fc == 3 for fc in data.get("face_vertex_counts", [])
-            )
-
-            return VerificationResult(
-                passed=is_triangulated,
-                constraint=constraint,
-                detail=f"{obj_name} triangulated: {is_triangulated} ({face_count} faces)",
-                measured={"face_count": face_count, "triangulated": is_triangulated}
-            )
-
-        elif constraint_type == "has_material":
-            obj_name = constraint.get("object")
-            mat_name = constraint.get("material_name")
-
-            if not obj_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object name",
-                    measured=None
+            if ctype == "facing":
+                return _fail(
+                    constraint,
+                    "generic object 'facing' is undefined without an explicit semantic forward axis; refusing to guess",
+                    {"rotation_euler": row.get("rotation_euler"), "requested_direction": constraint.get("direction")},
+                    status="not_proven",
                 )
 
-            result = send_command("get_materials", {"object": obj_name})
-            data = result.get("data", {})
-            materials = data.get("materials", [])
-            has_mat = mat_name in materials if mat_name else len(materials) > 0
-
-            return VerificationResult(
-                passed=has_mat,
-                constraint=constraint,
-                detail=f"{obj_name} materials: {materials}",
-                measured={"materials": materials, "has_target": has_mat}
-            )
-
-        elif constraint_type == "vertex_count_range":
-            obj_name = constraint.get("object")
-            min_v = constraint.get("min_vertices", 0)
-            max_v = constraint.get("max_vertices", 999999)
-
-            if not obj_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object name",
-                    measured=None
-                )
-
-            result = send_command("get_mesh_info", {"object": obj_name})
-            data = result.get("data", {})
-            vertex_count = data.get("vertex_count", 0)
-            in_range = min_v <= vertex_count <= max_v
-
-            return VerificationResult(
-                passed=in_range,
-                constraint=constraint,
-                detail=f"{obj_name} vertices: {vertex_count} (range: {min_v}-{max_v})",
-                measured={"vertex_count": vertex_count, "in_range": in_range}
-            )
-
-        elif constraint_type == "axis_aligned":
-            obj_name = constraint.get("object")
-            axis = constraint.get("axis", "z")
-            tolerance = constraint.get("tolerance", 0.05)
-
-            if not obj_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object name",
-                    measured=None
-                )
-
-            result = send_command("get_rotation", {"object": obj_name})
-            data = result.get("data", {})
-            rotation = data.get("rotation_euler", [0, 0, 0])
-
-            # Check if rotation around axis is near 0 or 180 degrees
-            axis_idx = {"x": 0, "y": 1, "z": 2}.get(axis.lower(), 2)
-            axis_rot = rotation[axis_idx] % 6.28318  # 2*pi
-            is_aligned = (axis_rot < tolerance) or (abs(axis_rot - 3.14159) < tolerance)
-
-            return VerificationResult(
-                passed=is_aligned,
-                constraint=constraint,
-                detail=f"{obj_name} axis {axis} alignment: {axis_rot:.3f} rad",
-                measured={"rotation_rad": axis_rot, "aligned": is_aligned}
-            )
-
-        elif constraint_type == "not_overlapping":
-            obj1 = constraint.get("object")
-            obj2 = constraint.get("support")
-
-            if not obj1 or not obj2:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object names",
-                    measured=None
-                )
-
-            result = send_command("check_overlap", {
-                "object1": obj1,
-                "object2": obj2
-            })
-            data = result.get("data", {})
-            overlapping = data.get("overlapping", False)
-
-            return VerificationResult(
-                passed=not overlapping,
-                constraint=constraint,
-                detail=f"{obj1} and {obj2} overlap: {overlapping}",
-                measured={"overlapping": overlapping}
-            )
-
-        elif constraint_type == "facing":
-            obj_name = constraint.get("object")
-            direction = constraint.get("direction", "z")
-            tolerance = constraint.get("tolerance", 0.1)
-
-            if not obj_name:
-                return VerificationResult(
-                    passed=False,
-                    constraint=constraint,
-                    detail="Missing object name",
-                    measured=None
-                )
-
-            result = send_command("get_normal", {"object": obj_name})
-            data = result.get("data", {})
-            normal = data.get("normal", [0, 0, 1])
-
-            target_map = {
-                "x": [1, 0, 0], "-x": [-1, 0, 0],
-                "y": [0, 1, 0], "-y": [0, -1, 0],
-                "z": [0, 0, 1], "-z": [0, 0, -1],
-            }
-            target_normal = target_map.get(direction, [0, 0, 1])
-
-            # Dot product with tolerance
-            dot = sum(n * t for n, t in zip(normal, target_normal))
-            aligned = dot > (1 - tolerance)
-
-            return VerificationResult(
-                passed=aligned,
-                constraint=constraint,
-                detail=f"{obj_name} facing {direction}: dot={dot:.3f}",
-                measured={"normal": normal, "target": target_normal, "dot": dot}
-            )
-
-        else:
-            return VerificationResult(
-                passed=False,
-                constraint=constraint,
-                detail=f"Unknown constraint type: {constraint_type}",
-                measured=None
-            )
-
-    except Exception as e:
-        return VerificationResult(
-            passed=False,
-            constraint=constraint,
-            detail=f"Constraint check error: {str(e)}",
-            measured=None
-        )
+        return _fail(constraint, f"unknown constraint type: {ctype}")
+    except Exception as exc:
+        return _fail(constraint, f"constraint check error: {exc}")
 
 
-def run_gcs(
-    send_command: Callable[[str, Dict[str, Any]], Dict[str, Any]],
-    constraints: List[Dict[str, Any]]
-) -> Dict[str, Any]:
-    """
-    Run all GCS constraints and return aggregated results.
-
-    Args:
-        send_command: Socket-based Blender command sender
-        constraints: List of constraint dicts
-
-    Returns:
-        {
-            "passed": bool (all constraints passed),
-            "failed": int (count of failed constraints),
-            "results": [VerificationResult, ...],
-            "score": float (0-1, fraction of passed constraints),
-            "timestamp": str (ISO 8601)
-        }
-    """
-    results = []
-    for constraint in constraints:
-        result = check_constraint(send_command, constraint)
-        results.append(result)
-
-    passed_count = sum(1 for r in results if r.passed)
-    total_count = len(results)
-    score = passed_count / total_count if total_count > 0 else 1.0
-
+def run_gcs(send_command: SendCommand, constraints: List[Dict[str, Any]]) -> Dict[str, Any]:
+    results = [check_constraint(send_command, constraint) for constraint in constraints]
+    passed_count = sum(1 for result in results if result.passed)
+    total = len(results)
     return {
-        "passed": passed_count == total_count,
-        "failed": total_count - passed_count,
-        "results": [asdict(r) for r in results],
-        "score": score,
-        "timestamp": datetime.utcnow().isoformat()
+        "passed": passed_count == total,
+        "failed": total - passed_count,
+        "results": [asdict(result) for result in results],
+        "score": passed_count / total if total else 1.0,
+        "timestamp": _now(),
     }
 
 
-def vlm_judge(
-    screenshot_b64: str,
-    expected: str,
-    api: str = "anthropic",
-    model: Optional[str] = None
-) -> Dict[str, Any]:
+def vlm_judge(screenshot_b64: str, expected: str, api: str = "client", model: Optional[str] = None) -> Dict[str, Any]:
+    """Never fabricate semantic image judgement inside the MCP server.
+
+    The screenshot is returned through MCP tool output for the client/model that
+    can actually inspect it. This function intentionally cannot return a visual
+    pass, regardless of environment variables or provider names.
     """
-    Use Vision-as-a-Judge to verify action outcome against expected state.
-
-    Args:
-        screenshot_b64: Base64-encoded PNG screenshot
-        expected: Natural language description of expected outcome
-        api: "anthropic", "openai", or "local"
-        model: Optional model override (defaults by api)
-
-    Returns:
-        {
-            "passed": bool,
-            "confidence": float (0-1),
-            "reasoning": str,
-            "provider": str,
-            "timestamp": str
-        }
-    """
-
-    if not model:
-        model = {
-            "anthropic": "claude-3-5-sonnet-20241022",
-            "openai": "gpt-4-vision",
-            "local": "llava"
-        }.get(api, "claude-3-5-sonnet-20241022")
-
-    prompt = (
-        f"You are a vision-based action verifier. Analyze this screenshot and determine "
-        f"if the following expected outcome is satisfied:\n\nExpected: {expected}\n\n"
-        f"Respond with JSON: {{'passed': bool, 'confidence': float (0-1), 'reasoning': str}}"
-    )
-
-    try:
-        if api == "anthropic":
-            import os
-            api_key = os.getenv("ANTHROPIC_API_KEY")
-            if not api_key:
-                return {
-                    "passed": False,
-                    "confidence": 0.0,
-                    "reasoning": "ANTHROPIC_API_KEY not set",
-                    "provider": api,
-                    "timestamp": datetime.utcnow().isoformat()
-                }
-
-            # Mock implementation (real would use anthropic SDK)
-            return {
-                "passed": True,
-                "confidence": 0.85,
-                "reasoning": f"Screenshot matches expectation: {expected}",
-                "provider": api,
-                "timestamp": datetime.utcnow().isoformat()
-            }
-
-        elif api == "openai":
-            api_key = os.getenv("OPENAI_API_KEY")
-            if not api_key:
-                return {
-                    "passed": False,
-                    "confidence": 0.0,
-                    "reasoning": "OPENAI_API_KEY not set",
-                    "provider": api,
-                    "timestamp": datetime.utcnow().isoformat()
-                }
-
-            # Mock implementation (real would use openai SDK)
-            return {
-                "passed": True,
-                "confidence": 0.80,
-                "reasoning": f"OpenAI verified: {expected}",
-                "provider": api,
-                "timestamp": datetime.utcnow().isoformat()
-            }
-
-        elif api == "local":
-            # Mock local model response
-            return {
-                "passed": True,
-                "confidence": 0.75,
-                "reasoning": f"Local model verified: {expected}",
-                "provider": api,
-                "timestamp": datetime.utcnow().isoformat()
-            }
-
-        else:
-            return {
-                "passed": False,
-                "confidence": 0.0,
-                "reasoning": f"Unknown VLM provider: {api}",
-                "provider": api,
-                "timestamp": datetime.utcnow().isoformat()
-            }
-
-    except Exception as e:
-        return {
-            "passed": False,
-            "confidence": 0.0,
-            "reasoning": f"VLM error: {str(e)}",
-            "provider": api,
-            "timestamp": datetime.utcnow().isoformat()
-        }
+    return {
+        "passed": False,
+        "status": "review_required",
+        "confidence": 0.0,
+        "reasoning": "Server-side VLM pass is disabled. A client with vision must inspect the returned pixels.",
+        "provider": api,
+        "model": model,
+        "pixel_evidence": bool(isinstance(screenshot_b64, str) and screenshot_b64.strip()),
+        "expected": expected,
+        "timestamp": _now(),
+    }
 
 
 def verify_action(
-    send_command: Callable[[str, Dict[str, Any]], Dict[str, Any]],
+    send_command: SendCommand,
     expected: str,
     constraints: Optional[List[Dict[str, Any]]] = None,
-    use_vlm: bool = True
+    use_vlm: bool = True,
 ) -> Dict[str, Any]:
-    """
-    Verify an action outcome using deterministic GCS + Vision-as-a-Judge fallback.
-
-    Args:
-        send_command: Socket-based Blender command sender
-        expected: Natural language description of expected outcome
-        constraints: Optional list of GCS constraint dicts
-        use_vlm: If True, use VLM for semantic verification
-
-    Returns:
-        {
-            "passed": bool,
-            "gcs_result": dict or None,
-            "vlm_result": dict or None,
-            "final_confidence": float (0-1),
-            "detail": str,
-            "timestamp": str
-        }
-    """
-
-    gcs_result = None
+    """Verify objective constraints and surface semantic review honestly."""
+    constraints = constraints or []
+    gcs_result = run_gcs(send_command, constraints)
+    detail: Dict[str, Any] = {"expected": expected, "objective": gcs_result}
     vlm_result = None
-    final_confidence = 0.0
+    review_required = False
 
-    # Step 1: Run deterministic GCS checks if provided
-    if constraints:
-        gcs_result = run_gcs(send_command, constraints)
-        final_confidence = gcs_result.get("score", 0.0)
+    if use_vlm:
+        observation = send_command("viewport_capture", {"base64": True})
+        obs_err = _error(observation)
+        image = _payload(observation).get("base64") if not obs_err else None
+        if obs_err or not isinstance(image, str) or not image.strip():
+            vlm_result = {
+                "passed": False,
+                "status": "unavailable",
+                "confidence": 0.0,
+                "reasoning": obs_err or "viewport returned no base64 pixels",
+                "pixel_evidence": False,
+                "timestamp": _now(),
+            }
+        else:
+            vlm_result = vlm_judge(image, expected)
+            review_required = True
+        detail["visual"] = vlm_result
 
-    # Step 2: Run VLM if requested and GCS inconclusive
-    if use_vlm and (not constraints or gcs_result.get("score", 0.0) < 0.95):
-        try:
-            result = send_command("take_screenshot", {})
-            screenshot_b64 = result.get("data", {}).get("screenshot", "")
-
-            if screenshot_b64:
-                vlm_result = vlm_judge(screenshot_b64, expected)
-                vlm_confidence = vlm_result.get("confidence", 0.0)
-
-                # Weight: if GCS exists, average; else use VLM
-                if gcs_result:
-                    final_confidence = (final_confidence + vlm_confidence) / 2
-                else:
-                    final_confidence = vlm_confidence
-        except Exception:
-            pass  # VLM verification optional
-
-    # Determine final pass
-    passed = final_confidence > 0.5
-
-    detail = f"Expected: {expected}. "
-    if gcs_result:
-        detail += f"GCS: {gcs_result['score']:.2f}. "
-    if vlm_result:
-        detail += f"VLM: {vlm_result['confidence']:.2f}. "
-    detail += f"Final confidence: {final_confidence:.2f}"
+    if not gcs_result["passed"]:
+        status = "failed"
+        passed = False
+        confidence = float(gcs_result["score"])
+    elif review_required:
+        status = "review_required"
+        passed = False
+        confidence = 0.0
+    elif use_vlm and vlm_result and vlm_result.get("status") == "unavailable":
+        status = "failed"
+        passed = False
+        confidence = 0.0
+    else:
+        status = "passed"
+        passed = True
+        confidence = float(gcs_result["score"])
 
     return {
         "passed": passed,
+        "status": status,
+        "review_required": review_required,
+        "final_confidence": confidence,
+        "detail": detail,
         "gcs_result": gcs_result,
         "vlm_result": vlm_result,
-        "final_confidence": final_confidence,
-        "detail": detail,
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": _now(),
     }

--- a/server/visual_quality.py
+++ b/server/visual_quality.py
@@ -1,0 +1,79 @@
+"""Deterministic visual-quality checks for Blender agent workflows.
+
+This is deliberately model-independent: it turns scene/render evidence into a
+stable quality report that an LLM can reason over without pretending that the
+mere existence of pixels means the result is good.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _payload(result: Any) -> dict:
+    if not isinstance(result, dict):
+        return {}
+    data = result.get("data", result)
+    return data if isinstance(data, dict) else {}
+
+
+def _objects(scene: Any) -> list[dict]:
+    rows = _payload(scene).get("objects") or []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def critique_visual_evidence(
+    *,
+    scene: Any,
+    viewport: Any,
+    workflow: str | None = None,
+    target_object: str | None = None,
+) -> dict:
+    """Return deterministic quality findings and an actionable revision plan.
+
+    This does not claim aesthetic understanding. It verifies objective scene
+    prerequisites and whether actual pixels were returned, then leaves semantic
+    image judgement to the model/client that can see those pixels.
+    """
+    payload = _payload(viewport)
+    pixels = next(
+        (payload.get(key) for key in ("base64", "image", "image_base64")
+         if isinstance(payload.get(key), str) and payload.get(key).strip()),
+        None,
+    )
+    objects = _objects(scene)
+    names = {str(row.get("name")) for row in objects if row.get("name")}
+    types = [str(row.get("type") or "").upper() for row in objects]
+    findings: list[dict] = []
+
+    def add(code: str, severity: str, message: str, fix: str) -> None:
+        findings.append({"code": code, "severity": severity, "message": message, "recommended_fix": fix})
+
+    if not pixels:
+        add("NO_PIXELS", "error", "No model-visible pixel payload was returned.", "Capture viewport pixels with base64=true before accepting visual quality.")
+    if not objects:
+        add("EMPTY_SCENE", "error", "Scene contains no inspectable objects.", "Inspect or rebuild the scene before visual review.")
+    if target_object and target_object not in names:
+        add("TARGET_MISSING", "error", f"Target object '{target_object}' is absent from the scene.", "Resolve the canonical object name before camera/material/render work.")
+    if workflow in {"workflow.product_hero", "workflow.amazon_packshot", "workflow.turntable"}:
+        if "CAMERA" not in types:
+            add("NO_CAMERA", "error", "Product workflow has no camera object.", "Create and aim a product camera at the target.")
+        if "LIGHT" not in types:
+            add("NO_LIGHTS", "error", "Product workflow has no light objects.", "Create a studio key/fill/rim lighting setup.")
+        if target_object and target_object in names and len(objects) < 3:
+            add("UNDERBUILT_STAGE", "warning", "Product stage has very little supporting scene structure.", "Inspect lighting, camera, background and shadow-catching support before final render.")
+    if workflow == "workflow.amazon_packshot":
+        add("AMAZON_SEMANTIC_REVIEW", "review", "Pixel evidence still requires semantic review for product framing, background cleanliness, legibility and unwanted props.", "Inspect the returned pixels before accepting the listing image.")
+    elif workflow in {"workflow.product_hero", "workflow.turntable"}:
+        add("AESTHETIC_REVIEW", "review", "Objective prerequisites pass only part of the quality bar.", "Inspect the returned pixels for composition, highlight shape, material readability, clipping and visual hierarchy.")
+
+    blocking = [row for row in findings if row["severity"] == "error"]
+    reviews = [row for row in findings if row["severity"] == "review"]
+    score = max(0, 100 - 30 * len(blocking) - 10 * len([r for r in findings if r["severity"] == "warning"]))
+    return {
+        "status": "fail" if blocking else "review_required" if reviews else "pass",
+        "objective_score": score,
+        "pixel_evidence": bool(pixels),
+        "findings": findings,
+        "revision_plan": [row["recommended_fix"] for row in findings if row["severity"] in {"error", "warning", "review"}],
+        "note": "Objective score is deterministic scene/evidence validation, not an aesthetic model score.",
+    }

--- a/server/visual_quality.py
+++ b/server/visual_quality.py
@@ -27,6 +27,7 @@ def critique_visual_evidence(
     viewport: Any,
     workflow: str | None = None,
     target_object: str | None = None,
+    diagnostics: Any = None,
 ) -> dict:
     """Return deterministic quality findings and an actionable revision plan.
 
@@ -40,7 +41,9 @@ def critique_visual_evidence(
          if isinstance(payload.get(key), str) and payload.get(key).strip()),
         None,
     )
-    objects = _objects(scene)
+    diag = _payload(diagnostics) if diagnostics is not None else {}
+    objects = diag.get("objects") if isinstance(diag.get("objects"), list) else _objects(scene)
+    objects = [row for row in objects if isinstance(row, dict)]
     names = {str(row.get("name")) for row in objects if row.get("name")}
     types = [str(row.get("type") or "").upper() for row in objects]
     findings: list[dict] = []
@@ -55,9 +58,14 @@ def critique_visual_evidence(
     if target_object and target_object not in names:
         add("TARGET_MISSING", "error", f"Target object '{target_object}' is absent from the scene.", "Resolve the canonical object name before camera/material/render work.")
     if workflow in {"workflow.product_hero", "workflow.amazon_packshot", "workflow.turntable"}:
-        if "CAMERA" not in types:
+        camera_present = bool(diag["camera_present"]) if "camera_present" in diag else "CAMERA" in types
+        if "light_count" in diag:
+            lights_present = int(diag.get("light_count") or 0) > 0
+        else:
+            lights_present = "LIGHT" in types
+        if not camera_present:
             add("NO_CAMERA", "error", "Product workflow has no camera object.", "Create and aim a product camera at the target.")
-        if "LIGHT" not in types:
+        if not lights_present:
             add("NO_LIGHTS", "error", "Product workflow has no light objects.", "Create a studio key/fill/rim lighting setup.")
         if target_object and target_object in names and len(objects) < 3:
             add("UNDERBUILT_STAGE", "warning", "Product stage has very little supporting scene structure.", "Inspect lighting, camera, background and shadow-catching support before final render.")

--- a/tests/test_bridge_contracts.py
+++ b/tests/test_bridge_contracts.py
@@ -6,6 +6,7 @@ from server.capability_registry import registry
 
 ADDON_PATH = Path("blender_addon/openclaw_blender_bridge.py")
 PHASE5_PATH = Path("blender_addon/new_handlers_phase5.py")
+QUALITY_PATH = Path("blender_addon/quality_handlers.py")
 
 
 def _source(path: Path = ADDON_PATH) -> str:
@@ -32,7 +33,8 @@ def _dict_keys(path: Path, required: set[str]) -> set[str]:
 def _registered_bridge_commands() -> set[str]:
     base = _dict_keys(ADDON_PATH, {"ping", "get_scene_info", "create_object", "viewport_capture"})
     phase5 = _dict_keys(PHASE5_PATH, {"spatial_raycast", "dimensions_estimate", "floor_plan_data"})
-    return base | phase5
+    quality = _dict_keys(QUALITY_PATH, {"scene_diagnostics"})
+    return base | phase5 | quality
 
 
 def test_phase5_handlers_are_merged_into_the_live_dispatch_dict():
@@ -41,6 +43,8 @@ def test_phase5_handlers_are_merged_into_the_live_dispatch_dict():
         "Phase 5 handlers must be merged into HANDLERS because process_command dispatches through HANDLERS"
     )
     assert "COMMANDS.update(_PHASE5_HANDLERS)" not in source
+    assert "HANDLERS.update(QUALITY_HANDLERS)" in source
+    assert registry.resolve_tool("scene.diagnostics").bridge_command == "scene_diagnostics"
 
 
 def test_every_registry_bridge_command_has_a_registered_addon_handler():

--- a/tests/test_bridge_e2e.py
+++ b/tests/test_bridge_e2e.py
@@ -128,3 +128,53 @@ def test_live_create_observe_delete(live_send):
     assert deleted["status"] == "ok"
     assert FIXTURE in (deleted.get("scene_delta") or {}).get("removed", [])
     assert _fixture_family(live_send) == []
+
+
+def test_live_product_hero_repairs_deleted_camera(live_send):
+    from server.capability_executor import execute_workflow
+
+    exec_probe = live_send("execute_python", {"code": "result = {'agent_os_probe': True}"})
+    if exec_probe.get("disabled_by_policy"):
+        message = "live camera-repair proof requires OPENCLAW_ALLOW_EXEC=1"
+        if REQUIRE:
+            pytest.fail(message)
+        pytest.skip(message)
+
+    created = execute_canonical(
+        "scene.create_object",
+        {"type": "cube", "name": FIXTURE, "location": [0, 0, 1], "size": 1.0},
+        live_send,
+        observe_visual=False,
+    )
+    assert created["status"] == "ok"
+
+    wiped = live_send(
+        "execute_python",
+        {
+            "code": (
+                "import bpy\n"
+                "removed = 0\n"
+                "for obj in list(bpy.data.objects):\n"
+                "    if obj.type == 'CAMERA':\n"
+                "        bpy.data.objects.remove(obj, do_unlink=True)\n"
+                "        removed += 1\n"
+                "result = {'removed_cameras': removed}\n"
+            )
+        },
+    )
+    assert not wiped.get("error"), wiped
+
+    out = execute_workflow("workflow.product_hero", {"object_name": FIXTURE, "auto_render": False}, live_send)
+    diag = live_send("scene_diagnostics", {})
+    if isinstance(diag, dict) and diag.get("error"):
+        message = f"scene_diagnostics not registered on live addon: {diag['error']}"
+        if REQUIRE:
+            pytest.fail(message)
+        pytest.skip(message)
+    assert diag.get("camera_present") is True or any(
+        (row.get("type") or "").upper() == "CAMERA" for row in (diag.get("objects") or []) if isinstance(row, dict)
+    )
+    assert out["status"] in {"review_required", "pass", "fail"}
+    if out["status"] == "fail":
+        codes = {row["code"] for row in (out.get("quality_review") or {}).get("findings") or []}
+        assert "NO_CAMERA" not in codes, out

--- a/tests/test_quality_repair.py
+++ b/tests/test_quality_repair.py
@@ -1,0 +1,50 @@
+from server.quality_loop import run_quality_loop
+from server.quality_repair import next_objective_repair, repair_for_finding
+
+
+def finding(code, severity="error"):
+    return {"code": code, "severity": severity}
+
+
+def test_review_findings_are_never_auto_repaired():
+    action = repair_for_finding(finding("AESTHETIC_REVIEW", "review"), workflow="workflow.product_hero", target_object="Bottle")
+    assert action.repairable is False
+    assert action.capability is None
+
+
+def test_target_missing_fails_closed_before_other_mutation():
+    review = {"status": "fail", "findings": [finding("TARGET_MISSING"), finding("NO_CAMERA")]}
+    action = next_objective_repair(review, workflow="workflow.product_hero", target_object="Bottle")
+    assert action is not None and action.repairable is False
+
+
+def test_loop_repairs_one_finding_then_recaptures():
+    state = {"camera": False, "reviews": 0, "mutations": []}
+    def review():
+        state["reviews"] += 1
+        if not state["camera"]:
+            return {"status": "fail", "findings": [finding("NO_CAMERA")]}
+        return {"status": "review_required", "findings": [finding("AESTHETIC_REVIEW", "review")], "pixel_evidence": True}
+    def execute(key, args):
+        state["mutations"].append((key, args))
+        assert key == "product.camera"
+        state["camera"] = True
+        return {"status": "ok"}
+    out = run_quality_loop(workflow="workflow.product_hero", target_object="Bottle", review_once=review, execute_canonical=execute, max_repairs=3)
+    assert out["status"] == "review_required"
+    assert state["reviews"] == 2
+    assert len(state["mutations"]) == 1
+    assert out["repair_count"] == 1
+
+
+def test_loop_stops_at_budget():
+    def review():
+        return {"status": "fail", "findings": [finding("NO_CAMERA")]}
+    calls = []
+    def execute(key, args):
+        calls.append(key)
+        return {"status": "ok"}
+    out = run_quality_loop(workflow="workflow.product_hero", target_object="Bottle", review_once=review, execute_canonical=execute, max_repairs=2)
+    assert out["status"] == "fail"
+    assert calls == ["product.camera", "product.camera"]
+    assert out["repair_count"] == 2

--- a/tests/test_visual_quality.py
+++ b/tests/test_visual_quality.py
@@ -33,3 +33,17 @@ def test_missing_target_is_failure():
     ]}, viewport={"base64": "pixels"}, workflow="workflow.product_hero", target_object="Bottle")
     assert report["status"] == "fail"
     assert "TARGET_MISSING" in {row["code"] for row in report["findings"]}
+
+
+def test_diagnostics_camera_flag_overrides_object_type_list():
+    report = critique_visual_evidence(
+        scene={"objects": [{"name": "Bottle", "type": "MESH"}]},
+        viewport={"base64": "pixels"},
+        diagnostics={"objects": [{"name": "Bottle", "type": "MESH"}, {"name": "Camera", "type": "CAMERA"}, {"name": "Key", "type": "LIGHT"}], "camera_present": True, "light_count": 1},
+        workflow="workflow.product_hero",
+        target_object="Bottle",
+    )
+    codes = {row["code"] for row in report["findings"]}
+    assert "NO_CAMERA" not in codes
+    assert "NO_LIGHTS" not in codes
+    assert report["status"] == "review_required"

--- a/tests/test_visual_quality.py
+++ b/tests/test_visual_quality.py
@@ -1,0 +1,35 @@
+from server.visual_quality import critique_visual_evidence
+
+
+def test_no_pixels_is_hard_failure():
+    report = critique_visual_evidence(scene={"objects": [{"name": "Bottle", "type": "MESH"}]}, viewport={"status": "ok"}, workflow="workflow.product_hero", target_object="Bottle")
+    assert report["status"] == "fail"
+    assert report["pixel_evidence"] is False
+    assert "NO_PIXELS" in {row["code"] for row in report["findings"]}
+
+
+def test_product_scene_requires_camera_and_lights():
+    report = critique_visual_evidence(scene={"objects": [{"name": "Bottle", "type": "MESH"}]}, viewport={"base64": "pixels"}, workflow="workflow.product_hero", target_object="Bottle")
+    codes = {row["code"] for row in report["findings"]}
+    assert {"NO_CAMERA", "NO_LIGHTS"} <= codes
+    assert report["status"] == "fail"
+
+
+def test_complete_product_scene_requires_semantic_review_not_fake_aesthetic_pass():
+    report = critique_visual_evidence(scene={"objects": [
+        {"name": "Bottle", "type": "MESH"},
+        {"name": "Camera", "type": "CAMERA"},
+        {"name": "Key", "type": "LIGHT"},
+    ]}, viewport={"data": {"base64": "pixels"}}, workflow="workflow.amazon_packshot", target_object="Bottle")
+    assert report["status"] == "review_required"
+    assert report["objective_score"] == 100
+    assert "AMAZON_SEMANTIC_REVIEW" in {row["code"] for row in report["findings"]}
+
+
+def test_missing_target_is_failure():
+    report = critique_visual_evidence(scene={"objects": [
+        {"name": "Camera", "type": "CAMERA"},
+        {"name": "Key", "type": "LIGHT"},
+    ]}, viewport={"base64": "pixels"}, workflow="workflow.product_hero", target_object="Bottle")
+    assert report["status"] == "fail"
+    assert "TARGET_MISSING" in {row["code"] for row in report["findings"]}

--- a/tests/test_visual_quality_live_contract.py
+++ b/tests/test_visual_quality_live_contract.py
@@ -7,12 +7,12 @@ class SceneBridge:
 
     def __call__(self, command, params=None):
         self.calls.append((command, params or {}))
-        if command == "get_scene_info":
+        if command == "scene_diagnostics":
             return {"objects": [
                 {"name": "Bottle", "type": "MESH"},
                 {"name": "Camera", "type": "CAMERA"},
                 {"name": "Key", "type": "LIGHT"},
-            ]}
+            ], "camera_present": True, "light_count": 1}
         if command == "viewport_capture":
             return {"base64": "pixels"}
         raise AssertionError(command)
@@ -20,9 +20,15 @@ class SceneBridge:
 
 def test_critic_contract_uses_scene_and_model_visible_pixels():
     bridge = SceneBridge()
-    scene = bridge("get_scene_info", {})
+    diagnostics = bridge("scene_diagnostics", {})
     viewport = bridge("viewport_capture", {"base64": True})
-    report = critique_visual_evidence(scene=scene, viewport=viewport, workflow="workflow.amazon_packshot", target_object="Bottle")
-    assert bridge.calls == [("get_scene_info", {}), ("viewport_capture", {"base64": True})]
+    report = critique_visual_evidence(
+        scene=diagnostics,
+        viewport=viewport,
+        diagnostics=diagnostics,
+        workflow="workflow.amazon_packshot",
+        target_object="Bottle",
+    )
+    assert bridge.calls == [("scene_diagnostics", {}), ("viewport_capture", {"base64": True})]
     assert report["pixel_evidence"] is True
     assert report["status"] == "review_required"

--- a/tests/test_visual_quality_live_contract.py
+++ b/tests/test_visual_quality_live_contract.py
@@ -1,0 +1,28 @@
+from server.visual_quality import critique_visual_evidence
+
+
+class SceneBridge:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, command, params=None):
+        self.calls.append((command, params or {}))
+        if command == "get_scene_info":
+            return {"objects": [
+                {"name": "Bottle", "type": "MESH"},
+                {"name": "Camera", "type": "CAMERA"},
+                {"name": "Key", "type": "LIGHT"},
+            ]}
+        if command == "viewport_capture":
+            return {"base64": "pixels"}
+        raise AssertionError(command)
+
+
+def test_critic_contract_uses_scene_and_model_visible_pixels():
+    bridge = SceneBridge()
+    scene = bridge("get_scene_info", {})
+    viewport = bridge("viewport_capture", {"base64": True})
+    report = critique_visual_evidence(scene=scene, viewport=viewport, workflow="workflow.amazon_packshot", target_object="Bottle")
+    assert bridge.calls == [("get_scene_info", {}), ("viewport_capture", {"base64": True})]
+    assert report["pixel_evidence"] is True
+    assert report["status"] == "review_required"

--- a/tests/test_workflow_execution.py
+++ b/tests/test_workflow_execution.py
@@ -13,6 +13,24 @@ class FakeBridge:
             return {"status": "ok", "image": "base64-test"}
         if command == "get_scene_info":
             return {"status": "ok", "objects": list(self.objects)}
+        if command == "scene_diagnostics":
+            types = [row.get("type") for row in self.objects]
+            lights = [row for row in self.objects if row.get("type") == "LIGHT"]
+            camera = next((row for row in self.objects if row.get("type") == "CAMERA"), None)
+            return {
+                "objects": list(self.objects),
+                "camera_present": camera is not None,
+                "light_count": len(lights),
+                "lights": lights,
+                "camera": camera,
+            }
+        if command == "execute_python":
+            names = {row["name"] for row in self.objects}
+            if "Camera" not in names:
+                self.objects.append({"name": "Camera", "type": "CAMERA"})
+            if "Key" not in names:
+                self.objects.append({"name": "Key", "type": "LIGHT"})
+            return {"status": "ok"}
         if command == "create_object":
             name = params.get("name") or "Cube"
             self.objects.append({"name": name, "type": "MESH"})
@@ -112,7 +130,7 @@ def test_product_hero_is_one_workflow_with_required_observations():
     bridge = FakeBridge()
     result = execute_workflow("workflow.product_hero", {"object_name": "Bottle", "material": "clear_glass", "lighting": "cosmetics", "camera_style": "hero_reveal", "quality": "premium", "resolution": "square_1080", "auto_render": True}, bridge)
     commands = [name for name, _ in bridge.calls]
-    assert result["status"] == "ok"
+    assert result["status"] == "review_required"
     assert commands[0] == "get_scene_info"
     assert commands.count("viewport_capture") >= 5
     assert "product_lighting" not in commands
@@ -125,7 +143,7 @@ def test_product_hero_is_one_workflow_with_required_observations():
 def test_workflow_render_uses_addon_image_type():
     bridge = FakeBridge()
     result = execute_workflow("workflow.product_hero", {"object_name": "Bottle", "auto_render": True}, bridge)
-    assert result["status"] == "ok"
+    assert result["status"] == "review_required"
     render_calls = [params for command, params in bridge.calls if command == "render"]
     assert render_calls == [{"type": "image"}]
 
@@ -158,7 +176,7 @@ def test_create_object_fails_closed_without_scene_delta():
 def test_turntable_workflow_uses_turntable_camera_style():
     bridge = FakeBridge()
     result = execute_workflow("workflow.turntable", {"object_name": "Bottle", "auto_render": False}, bridge)
-    assert result["status"] == "ok"
+    assert result["status"] == "review_required"
     camera_calls = [params for command, params in bridge.calls if command == "execute_python"]
     assert camera_calls, bridge.calls
     assert any("turntable" in str(params.get("code", "")).lower() or "Turntable" in str(params.get("code", "")) for params in camera_calls)
@@ -196,7 +214,7 @@ def test_path_only_viewport_capture_is_not_visual_evidence():
 def test_amazon_packshot_forces_square_premium_setup():
     bridge = FakeBridge()
     result = execute_workflow("workflow.amazon_packshot", {"object_name": "Bottle"}, bridge)
-    assert result["status"] == "ok"
+    assert result["status"] == "review_required"
     assert result["workflow"] == "workflow.amazon_packshot"
     assert "render" in [name for name, _ in bridge.calls]
 

--- a/tests/test_workflow_quality_gate.py
+++ b/tests/test_workflow_quality_gate.py
@@ -1,0 +1,48 @@
+from server.capability_executor import execute_workflow
+
+
+class FakeBridge:
+    def __init__(self, *, include_camera=True, include_light=True, pixels=True):
+        self.include_camera = include_camera
+        self.include_light = include_light
+        self.pixels = pixels
+
+    def __call__(self, command, params):
+        if command == "get_scene_info":
+            objects = [{"name": "Bottle", "type": "MESH"}]
+            if self.include_camera:
+                objects.append({"name": "Camera", "type": "CAMERA"})
+            if self.include_light:
+                objects.append({"name": "Key", "type": "LIGHT"})
+            return {"objects": objects}
+        if command == "viewport_capture":
+            return {"base64": "pixels" if self.pixels else ""}
+        if command in {"execute_python", "render"}:
+            return {"status": "ok"}
+        return {"status": "ok"}
+
+
+def test_product_hero_cannot_finish_plain_ok_when_semantic_review_is_required():
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, FakeBridge())
+    assert out["status"] == "review_required"
+    assert out["quality_review"]["pixel_evidence"] is True
+    assert out["quality_review"]["objective_score"] == 100
+    assert any(row["code"] == "AESTHETIC_REVIEW" for row in out["quality_review"]["findings"])
+
+
+def test_amazon_packshot_cannot_finish_plain_ok_before_semantic_review():
+    out = execute_workflow("workflow.amazon_packshot", {"object_name": "Bottle"}, FakeBridge())
+    assert out["status"] == "review_required"
+    assert any(row["code"] == "AMAZON_SEMANTIC_REVIEW" for row in out["quality_review"]["findings"])
+
+
+def test_product_workflow_fails_objective_quality_gate_without_camera():
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, FakeBridge(include_camera=False))
+    assert out["status"] == "fail"
+    assert any(row["code"] == "NO_CAMERA" for row in out["quality_review"]["findings"])
+
+
+def test_turntable_is_also_quality_gated():
+    out = execute_workflow("workflow.turntable", {"object_name": "Bottle"}, FakeBridge())
+    assert out["status"] == "review_required"
+    assert out["quality_review"]["objective_score"] == 100

--- a/tests/test_workflow_quality_gate.py
+++ b/tests/test_workflow_quality_gate.py
@@ -2,32 +2,89 @@ from server.capability_executor import execute_workflow
 
 
 class FakeBridge:
-    def __init__(self, *, include_camera=True, include_light=True, pixels=True):
+    def __init__(self, *, include_camera=True, include_light=True, pixels=True, objects=None):
         self.include_camera = include_camera
         self.include_light = include_light
         self.pixels = pixels
+        self.objects = list(objects) if objects is not None else [{"name": "Bottle", "type": "MESH"}]
+        self.calls = []
+        self._quality_started = False
 
-    def __call__(self, command, params):
-        if command == "get_scene_info":
-            objects = [{"name": "Bottle", "type": "MESH"}]
-            if self.include_camera:
-                objects.append({"name": "Camera", "type": "CAMERA"})
-            if self.include_light:
-                objects.append({"name": "Key", "type": "LIGHT"})
-            return {"objects": objects}
+    def _scene_objects(self):
+        rows = list(self.objects)
+        names = {row["name"] for row in rows}
+        if self.include_camera and "Camera" not in names:
+            rows.append({"name": "Camera", "type": "CAMERA"})
+        if self.include_light and "Key" not in names:
+            rows.append({"name": "Key", "type": "LIGHT"})
+        return rows
+
+    def _diagnostics(self):
+        rows = self._scene_objects()
+        types = [row["type"] for row in rows]
+        lights = [row for row in rows if row["type"] == "LIGHT"]
+        camera = next((row for row in rows if row["type"] == "CAMERA"), None)
+        return {
+            "objects": rows,
+            "object_count": len(rows),
+            "camera_present": camera is not None,
+            "camera": {"name": camera["name"], "lens_mm": 50.0, "dof_enabled": False} if camera else None,
+            "light_count": len(lights),
+            "lights": [{"name": row["name"], "type": "AREA", "energy": 100.0} for row in lights],
+            "world": {"present": True, "name": "World", "uses_nodes": False, "environment_textures": []},
+            "render": {"engine": "CYCLES", "samples": 256},
+        }
+
+    def __call__(self, command, params=None):
+        params = params or {}
+        self.calls.append((command, params))
+        if command in {"scene_diagnostics", "get_scene_info"}:
+            if command == "scene_diagnostics":
+                self._quality_started = True
+            payload = self._diagnostics()
+            if command == "get_scene_info":
+                return {"objects": payload["objects"]}
+            return payload
         if command == "viewport_capture":
+            if self._quality_started:
+                self.quality_viewports = getattr(self, "quality_viewports", 0) + 1
+                if getattr(self, "fail_first_quality_pixels", False) and self.quality_viewports == 1:
+                    return {"status": "ok"}
             return {"base64": "pixels" if self.pixels else ""}
-        if command in {"execute_python", "render"}:
+        if command == "execute_python":
+            code = str(params.get("code") or "")
+            if self._quality_started:
+                if "Product_Camera" in code or "ProductCamData" in code:
+                    self.include_camera = True
+                if "Key_Light" in code:
+                    self.include_light = True
+            return {"status": "ok"}
+        if command == "render":
             return {"status": "ok"}
         return {"status": "ok"}
 
 
+def _mutate_after_quality(bridge: FakeBridge) -> list[tuple]:
+    started = False
+    out = []
+    for command, params in bridge.calls:
+        if command == "scene_diagnostics":
+            started = True
+            continue
+        if started and command == "execute_python":
+            out.append((command, params))
+    return out
+
+
 def test_product_hero_cannot_finish_plain_ok_when_semantic_review_is_required():
-    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, FakeBridge())
+    bridge = FakeBridge()
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, bridge)
     assert out["status"] == "review_required"
     assert out["quality_review"]["pixel_evidence"] is True
     assert out["quality_review"]["objective_score"] == 100
     assert any(row["code"] == "AESTHETIC_REVIEW" for row in out["quality_review"]["findings"])
+    assert out["quality_review"].get("repair_count", 0) == 0
+    assert _mutate_after_quality(bridge) == []
 
 
 def test_amazon_packshot_cannot_finish_plain_ok_before_semantic_review():
@@ -36,13 +93,58 @@ def test_amazon_packshot_cannot_finish_plain_ok_before_semantic_review():
     assert any(row["code"] == "AMAZON_SEMANTIC_REVIEW" for row in out["quality_review"]["findings"])
 
 
-def test_product_workflow_fails_objective_quality_gate_without_camera():
-    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, FakeBridge(include_camera=False))
+def test_product_workflow_repairs_missing_camera_then_reviews():
+    bridge = FakeBridge(include_camera=False)
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, bridge)
+    assert out["status"] == "review_required"
+    assert out["quality_review"]["repair_count"] >= 1
+    assert not any(row["code"] == "NO_CAMERA" and row["severity"] == "error" for row in out["quality_review"]["findings"])
+    assert any(attempt.get("finding_code") == "NO_CAMERA" and attempt.get("capability") == "product.camera" for attempt in out["quality_review"]["repair_attempts"])
+    assert bridge.include_camera is True
+    assert "scene_diagnostics" in [name for name, _ in bridge.calls]
+
+
+def test_product_workflow_repairs_missing_lights():
+    bridge = FakeBridge(include_light=False)
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, bridge)
+    assert out["status"] == "review_required"
+    assert any(attempt.get("finding_code") == "NO_LIGHTS" for attempt in out["quality_review"]["repair_attempts"])
+    assert not any(row["code"] == "NO_LIGHTS" and row["severity"] == "error" for row in out["quality_review"]["findings"])
+
+
+def test_missing_target_fails_closed_without_stage_repair():
+    bridge = FakeBridge(objects=[{"name": "Other", "type": "MESH"}])
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, bridge)
     assert out["status"] == "fail"
-    assert any(row["code"] == "NO_CAMERA" for row in out["quality_review"]["findings"])
+    assert any(row["code"] == "TARGET_MISSING" for row in out["quality_review"]["findings"])
+    assert _mutate_after_quality(bridge) == []
+    assert not any(attempt.get("capability") in {"product.camera", "product.lighting"} for attempt in out["quality_review"].get("repair_attempts") or [])
 
 
 def test_turntable_is_also_quality_gated():
     out = execute_workflow("workflow.turntable", {"object_name": "Bottle"}, FakeBridge())
     assert out["status"] == "review_required"
     assert out["quality_review"]["objective_score"] == 100
+
+
+def test_missing_quality_pixels_are_recaptured():
+    bridge = FakeBridge()
+    bridge.fail_first_quality_pixels = True
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, bridge)
+    assert out["status"] == "review_required"
+    assert out["quality_review"]["pixel_evidence"] is True
+    assert any(attempt.get("finding_code") == "NO_PIXELS" for attempt in out["quality_review"]["repair_attempts"])
+
+
+def test_unknown_diagnostics_falls_back_to_scene_info():
+    class LegacyBridge(FakeBridge):
+        def __call__(self, command, params=None):
+            if command == "scene_diagnostics":
+                self.calls.append((command, params or {}))
+                return {"error": "Unknown command: scene_diagnostics"}
+            return super().__call__(command, params)
+
+    out = execute_workflow("workflow.product_hero", {"object_name": "Bottle"}, LegacyBridge())
+    assert out["status"] == "review_required"
+    assert out["quality_review"]["pixel_evidence"] is True
+


### PR DESCRIPTION
## Why
PR #15 made execution reliable, but pixel existence is not visual quality. PR #16 adds an objective quality control loop without fabricating aesthetic/semantic acceptance.

## Current slice
- deterministic visual critic over scene state + model-visible pixels
- addon-only `scene_diagnostics` handler for typed camera/light/world/render facts
- bounded detect → one objective repair → recapture → re-critique loop (default max 3)
- repair policy: NO_CAMERA → product.camera; NO_LIGHTS → product.lighting; NO_PIXELS → fresh capture; TARGET_MISSING → fail closed
- AESTHETIC_REVIEW / AMAZON_SEMANTIC_REVIEW are never auto-repaired or auto-accepted
- CI includes visual-quality and repair tests

## Hard merge gate
Do not merge until `scene_diagnostics` is registered in the actual addon HANDLERS/canonical registry, `_final_quality_review` uses the bounded controller, broken-camera/light FakeBridge tests are green, guided surface remains exactly five tools, and live Blender proof is green (or CI honestly skips when Blender is unavailable).

## Primary-source check
Blender exposes camera DOF, world node trees, render engine/settings, and viewport OpenGL capture as objective API state. Those facts may be deterministic inputs. Composition/material/listing-image semantics still require client-visible pixel review; no VLM/pass bit is introduced.